### PR TITLE
Change QoS depth

### DIFF
--- a/src/manager/source_driver_ros2.hpp
+++ b/src/manager/source_driver_ros2.hpp
@@ -120,7 +120,7 @@ inline void SourceDriver::Init(const YAML::Node& config)
 
   node_ptr_.reset(new rclcpp::Node("hesai_ros_driver_node"));
   if (driver_param.input_param.send_point_cloud_ros) {
-    pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(driver_param.input_param.ros_send_point_topic, 100);
+    pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(driver_param.input_param.ros_send_point_topic, 10);
   }
 
 


### PR DESCRIPTION
The current code has a QoS depth of 100, which is too large and causing issues with ROSbag recording. Therefore, we will improve performance and availability by changing the depth from 100 to 10.