### PR TITLE
Fix: Allow node renaming in ROS2 to avoid duplicate nodes (#22)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/driver/HesaiLidar_SDK_2.0"]
 	path = src/driver/HesaiLidar_SDK_2.0
-	url = https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0.git
+	url = https://github.com/foiegreis/HesaiLidar_SDK_2.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/driver/HesaiLidar_SDK_2.0"]
 	path = src/driver/HesaiLidar_SDK_2.0
-	url = https://github.com/foiegreis/HesaiLidar_SDK_2.0
+	url = https://github.com/foiegreis/HesaiLidar_SDK_2.0.git

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,6 +30,7 @@ lidar:
       device_udp_src_port: 0               # Filter point clouds for specified source ports in case of multiple lidar, setting >=1024
       device_fault_port: 0                 # Filter fault message for specified source ports in case of multiple lidar, setting >=1024
     ros:
+      ros_node_name: hesai_ros_driver_node          #Node name in ros. Allows for different naming when multiple sensors are in use
       ros_frame_id: hesai_lidar                     #Frame id of packet message and point cloud message
       # ros_recv_correction_topic: /lidar_corrections #Topic used to receive corrections file from rosbag
       ros_recv_packet_topic: /lidar_packets         #Topic used to receive lidar packets from rosbag

--- a/src/manager/source_drive_common.hpp
+++ b/src/manager/source_drive_common.hpp
@@ -50,6 +50,7 @@ public:
         YamlRead<bool>(       config["ros"], "send_packet_ros",            driver_param.input_param.send_packet_ros, false);
         YamlRead<bool>(       config["ros"], "send_point_cloud_ros",       driver_param.input_param.send_point_cloud_ros, false);
         YamlRead<std::string>(config["ros"], "ros_frame_id",               driver_param.input_param.frame_id, "hesai_lidar");
+        YamlRead<std::string>(config["ros"], "ros_node_name",              driver_param.input_param.ros_node_name, "hesai_ros_driver_node");
         YamlRead<std::string>(config["ros"], "ros_send_packet_topic",      driver_param.input_param.ros_send_packet_topic, "hesai_packets");
         YamlRead<std::string>(config["ros"], "ros_send_point_cloud_topic", driver_param.input_param.ros_send_point_topic, "hesai_points");
         YamlRead<std::string>(config["ros"], "ros_recv_packet_topic",      driver_param.input_param.ros_recv_packet_topic, "hesai_packets");

--- a/src/manager/source_driver_ros2.hpp
+++ b/src/manager/source_driver_ros2.hpp
@@ -98,6 +98,7 @@ protected:
   // Convert packets into ROS messages
   hesai_ros_driver::msg::UdpFrame ToRosMsg(const UdpFrame_t& ros_msg, double timestamp);
   std::string frame_id_;
+  std::string ros_node_name_;
 
   rclcpp::Subscription<std_msgs::msg::UInt8MultiArray>::SharedPtr crt_sub_;
   rclcpp::Subscription<hesai_ros_driver::msg::UdpFrame>::SharedPtr pkt_sub_;
@@ -117,8 +118,9 @@ inline void SourceDriver::Init(const YAML::Node& config)
   DriveYamlParam yaml_param;
   yaml_param.GetDriveYamlParam(config, driver_param);
   frame_id_ = driver_param.input_param.frame_id;
+  ros_node_name_ = driver_param.input_param.ros_node_name;
 
-  node_ptr_.reset(new rclcpp::Node("hesai_ros_driver_node"));
+  node_ptr_.reset(new rclcpp::Node(ros_node_name_));
   if (driver_param.input_param.send_point_cloud_ros) {
     pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(driver_param.input_param.ros_send_point_topic, 100);
   }


### PR DESCRIPTION
## Fix: Allow node renaming in ROS2
This PR addresses the issue where launching multiple Hesai LiDAR sensors results in multiple nodes with the same name.
Referring to the issue [https://github.com/HesaiTechnology/HesaiLidar_ROS_2.0/issues/22]

### 🔹 Changes:
- Added a new parameter `ros_node_name` in the config file to allow setting custom node names.
- Modified `source_drive_common.hpp` and `source_driver_ros2.hpp` 
- Modified `driver_param.h` in the submodule `driver` to include:
  ```cpp
  std::string ros_node_name;
- Modified the .gitmodules file to point to my fork

It was my first PR with submodules, I may have missed something
Please refer to PR request for the HesaiLidarSDK: [https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0/pull/20]

