### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
   
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>roslib</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">roslib</build_depend>
   <build_depend>std_msgs</build_depend>
   
   <exec_depend condition="$ROS_VERSION == 2">rclcpp</exec_depend>


### PR DESCRIPTION
roslib is a ros1 package. This is preventing rosdep from resolving its key using ROS2 versions