### PR TITLE
Fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,15 @@ if($ENV{ROS_VERSION} MATCHES "2")
   install(TARGETS
     hesai_ros_driver_node
     DESTINATION lib/${PROJECT_NAME})
+  install(TARGETS
+    source_lib
+    container_lib
+    ptcClient_lib
+    ptcParser_lib
+    serialClient_lib
+    log_lib
+    platutils_lib
+    DESTINATION lib)
 
   install(DIRECTORY
     launch

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
   
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>roslib</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">roslib</build_depend>
   <build_depend>std_msgs</build_depend>
   
   <exec_depend condition="$ROS_VERSION == 2">rclcpp</exec_depend>


### PR DESCRIPTION
Hello,


I would like to use the node built without the `--symlink-install` flag for the colon build.

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR271-R279): Added installation targets for several libraries to ensure they are installed correctly when building the project.
* [`package.xml`](diffhunk://#diff-37a67ff78eb7260214b323353263b9af40a2fa98719a1e81937fae0159df87a3L17-R17): Updated the `roslib` build dependency to be conditionally included only when building for ROS 1.

Thank you
