### PR TITLE
add workaround init code to deal with config_path param in ROS2

### DIFF
--- a/node/hesai_ros_driver_node.cc
+++ b/node/hesai_ros_driver_node.cc
@@ -81,6 +81,15 @@ int main(int argc, char** argv)
   {
     config_path = path;
   }
+#elif ROS2_FOUND
+  // workaround to get config_path from ros parameter
+  auto node = rclcpp::Node::make_shared("hesai_ros_driver_node");
+  std::string path = node->declare_parameter<std::string>("config_path", "");
+  node.reset();
+  if (!path.empty())
+  {
+    config_path = path;
+  }
 #endif
 
   YAML::Node config;

--- a/node/hesai_ros_driver_node.cu
+++ b/node/hesai_ros_driver_node.cu
@@ -85,6 +85,15 @@ int main(int argc, char** argv)
   {
     config_path = path;
   }
+#elif ROS2_FOUND
+  // workaround to get config_path from ros parameter
+  auto node = rclcpp::Node::make_shared("hesai_ros_driver_node");
+  std::string path = node->declare_parameter<std::string>("config_path", "");
+  node.reset();
+  if (!path.empty())
+  {
+    config_path = path;
+  }
 #endif
 
   YAML::Node config;


### PR DESCRIPTION
- ROS1 node can take config_path as a parameter.
- ROS2 node reads config from a fixed path `/path/to/src/config/config.yaml`, which is not convenient especially built without `--symlink-install`.
  - #27 
- ROS2 requires a node to get a parameter, so the code will make a temporal node to get the `config_path` param and then destroy the node.