### PR TITLE
Fixed meauserement units according to ros conventions

### DIFF
--- a/src/manager/source_driver_ros1.hpp
+++ b/src/manager/source_driver_ros1.hpp
@@ -81,6 +81,11 @@ protected:
   void SendFiretime(const double *firetime_correction_);
   // Used to publish the imu packet
   void SendImuConfig(const LidarImuData& msg);
+  // Convert Linear Acceleration from g to m/s^2
+  double From_g_To_ms2(double g);
+  // Convert Angular Velocity from degree/s to radian/s
+  double From_degs_To_rads(double degree);
+  
   // Convert ptp lock offset, status into ROS message
   hesai_ros_driver::Ptp ToRosMsg(const uint8_t& ptp_lock_offset, const u8Array_t& ptp_status);
   // Convert packet loss condition into ROS message
@@ -349,6 +354,16 @@ inline hesai_ros_driver::Firetime SourceDriver::ToRosMsg(const double *firetime_
   return msg;
 }
 
+inline double SourceDriver::From_g_To_ms2(double g)
+{
+  return g * 9.80665;
+}
+
+inline double SourceDriver::From_degs_To_rads(double degree)
+{
+  return degree * M_PI / 180.0;
+}
+
 inline sensor_msgs::Imu SourceDriver::ToRosMsg(const LidarImuData &imu_config_)
 {
   sensor_msgs::Imu ros_msg;
@@ -359,12 +374,12 @@ inline sensor_msgs::Imu SourceDriver::ToRosMsg(const LidarImuData &imu_config_)
     printf("ros1 does not support timestamps greater than 19 January 2038 03:14:07 (now %lf)\n", imu_config_.timestamp);
   }
   ros_msg.header.frame_id = frame_id_;
-  ros_msg.linear_acceleration.x = imu_config_.imu_accel_x;
-  ros_msg.linear_acceleration.y = imu_config_.imu_accel_y;
-  ros_msg.linear_acceleration.z = imu_config_.imu_accel_z;
-  ros_msg.angular_velocity.x = imu_config_.imu_ang_vel_x;
-  ros_msg.angular_velocity.y = imu_config_.imu_ang_vel_y;
-  ros_msg.angular_velocity.z = imu_config_.imu_ang_vel_z;
+  ros_msg.linear_acceleration.x = From_g_To_ms2(imu_config_.imu_accel_x);
+  ros_msg.linear_acceleration.y = From_g_To_ms2(imu_config_.imu_accel_y);
+  ros_msg.linear_acceleration.z = From_g_To_ms2(imu_config_.imu_accel_z);
+  ros_msg.angular_velocity.x = From_degs_To_rads(imu_config_.imu_ang_vel_x);
+  ros_msg.angular_velocity.y = From_degs_To_rads(imu_config_.imu_ang_vel_y);
+  ros_msg.angular_velocity.z = From_degs_To_rads(imu_config_.imu_ang_vel_z);
   return ros_msg;
 }
 

--- a/src/manager/source_driver_ros2.hpp
+++ b/src/manager/source_driver_ros2.hpp
@@ -87,6 +87,10 @@ protected:
   void SendFiretime(const double *firetime_correction_);
   // Used to publish the imu packet
   void SendImuConfig(const LidarImuData& msg);
+  // Convert Linear Acceleration from g to m/s^2
+  double From_g_To_ms2(double g);
+  // Convert Angular Velocity from degree/s to radian/s
+  double From_degs_To_rads(double degree);
 
   // Convert ptp lock offset, status into ROS message
   hesai_ros_driver::msg::Ptp ToRosMsg(const uint8_t& ptp_lock_offset, const u8Array_t& ptp_status);
@@ -354,6 +358,16 @@ inline hesai_ros_driver::msg::Firetime SourceDriver::ToRosMsg(const double *fire
   return msg;
 }
 
+inline double SourceDriver::From_g_To_ms2(double g)
+{
+  return g * 9.80665;
+}
+
+inline double SourceDriver::From_degs_To_rads(double degree)
+{
+  return degree * M_PI / 180.0;
+}
+
 inline sensor_msgs::msg::Imu SourceDriver::ToRosMsg(const LidarImuData &imu_config_)
 {
   sensor_msgs::msg::Imu ros_msg;
@@ -365,12 +379,12 @@ inline sensor_msgs::msg::Imu SourceDriver::ToRosMsg(const LidarImuData &imu_conf
     printf("does not support timestamps greater than 19 January 2038 03:14:07 (now %lf)\n", imu_config_.timestamp);
   }
   ros_msg.header.frame_id = frame_id_;
-  ros_msg.linear_acceleration.x = imu_config_.imu_accel_x;
-  ros_msg.linear_acceleration.y = imu_config_.imu_accel_y;
-  ros_msg.linear_acceleration.z = imu_config_.imu_accel_z;
-  ros_msg.angular_velocity.x = imu_config_.imu_ang_vel_x;
-  ros_msg.angular_velocity.y = imu_config_.imu_ang_vel_y;
-  ros_msg.angular_velocity.z = imu_config_.imu_ang_vel_z;
+  ros_msg.linear_acceleration.x = From_g_To_ms2(imu_config_.imu_accel_x);
+  ros_msg.linear_acceleration.y = From_g_To_ms2(imu_config_.imu_accel_y);
+  ros_msg.linear_acceleration.z = From_g_To_ms2(imu_config_.imu_accel_z);
+  ros_msg.angular_velocity.x = From_degs_To_rads(imu_config_.imu_ang_vel_x);
+  ros_msg.angular_velocity.y = From_degs_To_rads(imu_config_.imu_ang_vel_y);
+  ros_msg.angular_velocity.z = From_degs_To_rads(imu_config_.imu_ang_vel_z);
   return ros_msg;
 }
 


### PR DESCRIPTION
From ros documentation of "sensor_msgs/msg/Imu.msg":
"Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec".

This output publish the values in g and in degree/sec

solves #31  