### PR TITLE
fix: set SDK_2.0 submodule to track upstream master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/driver/HesaiLidar_SDK_2.0"]
 	path = src/driver/HesaiLidar_SDK_2.0
 	url = https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,10 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
 endif()
 
 if(($ENV{ROS_DISTRO} STREQUAL "jazzy"))
-add_definitions(-std=c++17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 elseif($ENV{ROS_DISTRO} STREQUAL "humble")  # the ros2 humble requires c++17
-add_definitions(-std=c++17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 else()
 add_definitions(-std=c++14)
 endif()
@@ -232,7 +232,13 @@ if($ENV{ROS_VERSION} MATCHES "2")
   "sensor_msgs" 
   # "tf2_geometry_msgs"
   )
+
+if(($ENV{ROS_DISTRO} STREQUAL "jazzy") OR ($ENV{ROS_DISTRO} STREQUAL "humble"))
+  rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+  target_link_libraries(hesai_ros_driver_node "${cpp_typesupport_target}")
+else()
   rosidl_target_interfaces(hesai_ros_driver_node  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+endif()
 
   install(TARGETS
           hesai_ros_driver_node


### PR DESCRIPTION
- .gitmodules now tracks master branch of https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0
- Updated submodule pointer to latest master commit
- Prevents future broken submodule references and clone errors