### PR TITLE
Remove manual dependency installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          apt-get update
-          apt-get install -y \
-            libboost-all-dev \
-            libyaml-cpp-dev
-
       - id: ros_ci
         uses: ros-tooling/action-ros-ci@v0.4
         with:

--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ Install ROS related dependency libraries, please refer to: http://wiki.ros.org
 - Ubuntu 22.04 - ROS2 Humble desktop
 - Ubuntu 24.04 - ROS2 Jazzy desktop
 
-### Install Boost
-
-    sudo apt-get update
-    sudo apt-get install libboost-all-dev
-
-### Install Yaml
-
-    sudo apt-get update
-    sudo apt-get install -y libyaml-cpp-dev
-
 ### Clone
 
     git clone --recurse-submodules https://github.com/HesaiTechnology/HesaiLidar_ROS_2.0.git

--- a/package.xml
+++ b/package.xml
@@ -11,10 +11,10 @@
   <buildtool_depend condition="$ROS_VERSION == 2">rosidl_default_generators</buildtool_depend>
 
   <!-- Common Dependencies -->
-  <build_depend>yaml-cpp</build_depend>
   <depend>boost</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>yaml-cpp</depend>
   
   <!-- ROS1 -->
   <depend condition="$ROS_VERSION == 1">roscpp</depend>

--- a/package.xml
+++ b/package.xml
@@ -10,16 +10,18 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">rosidl_default_generators</buildtool_depend>
 
+  <!-- Common Dependencies -->
+  <build_depend>yaml-cpp</build_depend>
+  <depend>boost</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  
   <!-- ROS1 -->
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
-  <depend condition="$ROS_VERSION == 1">sensor_msgs</depend>
   <depend condition="$ROS_VERSION == 1">roslib</depend>
-  <depend condition="$ROS_VERSION == 1">std_msgs</depend>
 
   <!-- ROS2 -->
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
-  <depend condition="$ROS_VERSION == 2">sensor_msgs</depend>
-  <depend condition="$ROS_VERSION == 2">std_msgs</depend>
   <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp_action</depend>
 


### PR DESCRIPTION
Make boost, yaml-cpp installable by rosdep instead of manual steps to make the ROS package standalone